### PR TITLE
Fix missing definitions of ARCH_X86_64, HIGH_BIT_DEPTH and BIT_DEPTH for asm sources

### DIFF
--- a/SMP/libx264.vcxproj
+++ b/SMP/libx264.vcxproj
@@ -251,6 +251,7 @@
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>PREFIX;STACK_ALIGNMENT=4;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=0;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -321,6 +322,7 @@ del /f /q $(OutDir)\licenses\x264.txt
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>STACK_ALIGNMENT=16;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=1;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -401,6 +403,7 @@ copy ..\COPYING $(OutDir)\licenses\x264.txt</Command>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>PREFIX;STACK_ALIGNMENT=4;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=0;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -473,6 +476,7 @@ copy ..\COPYING $(OutDir)\licenses\x264.txt</Command>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>STACK_ALIGNMENT=16;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=1;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -547,6 +551,7 @@ del /f /q $(OutDir)\licenses\x264.txt
     <YASM>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>PREFIX;STACK_ALIGNMENT=4;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=0;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -628,6 +633,7 @@ del /f /q $(OutDir)\licenses\x264.txt
     <YASM>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>PREFIX;STACK_ALIGNMENT=4;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=0;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -709,6 +715,7 @@ del /f /q $(OutDir)\licenses\x264.txt
     <YASM>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>STACK_ALIGNMENT=16;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=1;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -790,6 +797,7 @@ del /f /q $(OutDir)\licenses\x264.txt
     <YASM>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>STACK_ALIGNMENT=16;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=1;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -874,6 +882,7 @@ del /f /q $(OutDir)\licenses\x264.txt
     <YASM>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>PREFIX;STACK_ALIGNMENT=4;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=0;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (
@@ -957,6 +966,7 @@ del /f /q $(OutDir)\licenses\x264.txt
     <YASM>
       <IncludePaths>$(ProjectDir)\..\common\x86;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>STACK_ALIGNMENT=16;HIGH_BIT_DEPTH=0;BIT_DEPTH=8;WIN32=1;ARCH_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Defines>HIGH_BIT_DEPTH=0;BIT_DEPTH=8;ARCH_X86_64=1;</Defines>
     </YASM>
     <PreBuildEvent>
       <Command>if exist ..\config.h (


### PR DESCRIPTION
When using vsyasm 1.2.0 or 1.3.0 (by renaming the vsyasm.pros to yasm.props), the sources could not be compiled and the error is macros undefined.

<!--- Provide a general summary of the enhancement in the Title above -->

## Context
WIndows 10
Visual Studio 2013
vsyasm.props 1.2.0 (rename as yasm.props, as same as yasm.xml and yasm.targets).

## Current and Suggested Behavior
Add macro definitions in the vc project.

## Steps to Explain Enhancement
1. Download vsyasm1.2.0 through yasm project (http://yasm.tortall.net/Download.html).
2. rename "vsyasm.props, vsyasm.targets, vsyasm.xml" to "yasm.props, yasm.targets, yasm.xml". and copy them into dir: 
C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\BuildCustomizations
3. copy vsyasm.exe to 
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
4. open the SMP\libx264.sln solution and build. You will get the error messages.

## Your Test Environment
* Version Used: master 2017/04/13 22:46:27
* Operating System and Version(s):  Windows 10
* Compiler and version(s): Visual Studio 2013 Update 5